### PR TITLE
Relay memo for swaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ npx fuckyea deploy <network>
 
 You will need [`spring`](https://github.com/AntelopeIO/spring), and [`cdt`](https://github.com/AntelopeIO/cdt).
 
-You must have the [`eos-system-contracts`](https://github.com/eosnetworkfoundation/eos-system-contracts) locally, and built already.
+You must have the [`system-contracts`](https://github.com/VaultaFoundation/system-contracts) locally, and built already.
 Add their location to your path: 
 
 ```bash
-export SYSTEM_CONTRACTS_PATH=/path/to/eos-system-contracts/build
+export SYSTEM_CONTRACTS_PATH=/path/to/system-contracts/build
 ```
 
 Then create a build directory:

--- a/contracts/system.entry.cpp
+++ b/contracts/system.entry.cpp
@@ -152,7 +152,7 @@ void system_contract::on_transfer(const name& from, const name& to, const asset&
 
    check(quantity.symbol == EOS, "Invalid symbol");
    asset swap_amount = asset(quantity.amount, get_token_symbol());
-   transfer_action(get_self(), {{get_self(), "active"_n}}).send(get_self(), from, swap_amount, std::string(""));
+   transfer_action(get_self(), {{get_self(), "active"_n}}).send(get_self(), from, swap_amount, std::cref(memo));
 }
 
 // Allows an account to block themselves from being a recipient of the `swapto` action.

--- a/tests/eosio.system_tester.hpp
+++ b/tests/eosio.system_tester.hpp
@@ -24,7 +24,7 @@ public:
    // -----------------
    // static utilities
    // -----------------
-   static constexpr account_name xyz_name = "xyz"_n;
+   static constexpr account_name xyz_name = "core.vaulta"_n;
    static constexpr account_name eos_name = "eosio"_n;
 
    static asset eos(const char* amount) { return core_sym::from_string(amount); }


### PR DESCRIPTION
This makes sure that a memo is forwarded on the swap transfer. 

This also fixes the tests for the new system contracts requirement that deposit comes from `core.vaulta` and updates links in the readme. 